### PR TITLE
[iOS] Added way to turn off moving lightbox animation

### DIFF
--- a/ios/RCCLightBox.m
+++ b/ios/RCCLightBox.m
@@ -15,6 +15,7 @@ const NSInteger kLightBoxTag = 0x101010;
 @property (nonatomic, strong) UIView *overlayColorView;
 @property (nonatomic, strong) NSDictionary *params;
 @property (nonatomic)         BOOL yellowBoxRemoved;
+@property (nonatomic)         BOOL disableAffineTransform;
 @end
 
 @implementation RCCLightBoxView
@@ -28,6 +29,7 @@ const NSInteger kLightBoxTag = 0x101010;
         
         self.params = params;
         self.yellowBoxRemoved = NO;
+        self.disableAffineTransform = NO;
         
         NSDictionary *passProps = self.params[@"passProps"];
         
@@ -60,6 +62,11 @@ const NSInteger kLightBoxTag = 0x101010;
                 UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissAnimated)];
                 singleTap.delegate = self;
                 [self addGestureRecognizer:singleTap];
+            }
+          
+            if (style[@"disableAffineTransform"] != nil && [RCTConvert BOOL:style[@"disableAffineTransform"]])
+            {
+              self.disableAffineTransform = YES;
             }
         }
         
@@ -164,11 +171,15 @@ const NSInteger kLightBoxTag = 0x101010;
          }];
     }
     
-    self.reactView.transform = CGAffineTransformMakeTranslation(0, 100);
+    if (!self.disableAffineTransform) {
+      self.reactView.transform = CGAffineTransformMakeTranslation(0, 100);
+    }
     self.reactView.alpha = 0;
     [UIView animateWithDuration:0.6 delay:0.2 usingSpringWithDamping:0.65 initialSpringVelocity:0 options:UIViewAnimationOptionCurveEaseOut animations:^()
     {
-        self.reactView.transform = CGAffineTransformIdentity;
+        if (!self.disableAffineTransform) {
+          self.reactView.transform = CGAffineTransformMakeTranslation(0, 100);
+        }
         self.reactView.alpha = 1;
     } completion:nil];
 }
@@ -179,7 +190,9 @@ const NSInteger kLightBoxTag = 0x101010;
     
     [UIView animateWithDuration:0.2 animations:^()
     {
-        self.reactView.transform = CGAffineTransformMakeTranslation(0, 80);
+        if (!self.disableAffineTransform) {
+          self.reactView.transform = CGAffineTransformMakeTranslation(0, 80);
+        }
         self.reactView.alpha = 0;
     }
                      completion:^(BOOL finished)


### PR DESCRIPTION
This adds a way to turn off the affine transform that occurs during show/dismiss animation.

``` objc
Navigation.showLightBox({
      screen: 'example.CreateAccountScreen',
      style: {
        backgroundBlur: 'dark', // 'dark' / 'light' / 'xlight' / 'none' - the type of blur on the background
        tapBackgroundToDismiss: true, // dismisses LightBox on background taps (optional)
        disableAffineTransform: true, // disable affineTransform during animation      
},
```
This will work only in ios and has not been testing on Android.